### PR TITLE
Feature/add script args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
 "scripts" :{
     ...
     "cy:run": "cypress run", // It can be any cypress command with any argument
-    "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d <your-cypress-specs-folder>"
+    "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypress-cmd-args>\"'"
     ...
 }
  ```
+
+### With Arguments
+
+Sample:
+
+```
+-a '\"--config baseUrl=http://localhost:3000\"'
+```
 
 ## Launch the new script
 
@@ -37,13 +45,15 @@ npm run cy:parallel
 ```
 
 ### Scripts options
-| Option       | Alias    | Description                 | Type     |
-| ------------ | -------- | --------------------------- | ---------|
-| --help       |          | Show help                   |          |
-| --version    |          | Show version number         |          |
-| --script     | -s       | Your npm Cypress command    | string   |
-| --threads    | -t       | Number of threads           | number   |
-| --specsDir   | -d       | Cypress specs directory.    | string   |
+
+| Option     | Alias | Description                        | Type   |
+| ---------- | ----- | ---------------------------------- | ------ |
+| --help     |       | Show help                          |        |
+| --version  |       | Show version number                |        |
+| --script   | -s    | Your npm Cypress command           | string |
+| --args     | -a    | Your npm Cypress command arguments | string |
+| --threads  | -t    | Number of threads                  | number |
+| --specsDir | -d    | Cypress specs directory.           | string |
 
 # Contributors
 Looking for contributors.

--- a/lib/README.md
+++ b/lib/README.md
@@ -25,10 +25,18 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
 "scripts" :{
     ...
     "cy:run": "cypress run", // It can be any cypress command with any argument
-    "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d <your-cypress-specs-folder>"
+    "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypress-cmd-args>\"'"
     ...
 }
  ```
+
+### With Arguments
+
+Sample:
+
+```
+-a '\"--config baseUrl=http://localhost:3000\"'
+```
 
 ## Launch the new script
 
@@ -37,13 +45,15 @@ npm run cy:parallel
 ```
 
 ### Scripts options
-| Option       | Alias    | Description                 | Type     |
-| ------------ | -------- | --------------------------- | ---------|
-| --help       |          | Show help                   |          |
-| --version    |          | Show version number         |          |
-| --script     | -s       | Your npm Cypress command    | string   |
-| --threads    | -t       | Number of threads           | number   |
-| --specsDir   | -d       | Cypress specs directory.    | string   |
+
+| Option     | Alias | Description                        | Type   |
+| ---------- | ----- | ---------------------------------- | ------ |
+| --help     |       | Show help                          |        |
+| --version  |       | Show version number                |        |
+| --script   | -s    | Your npm Cypress command           | string |
+| --args     | -a    | Your npm Cypress command arguments | string |
+| --threads  | -t    | Number of threads                  | number |
+| --specsDir | -d    | Cypress specs directory.           | string |
 
 # Contributors
 Looking for contributors.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,6 +20,11 @@ const argv = yargs
     alias: 'd',
     type: 'string',
     description: 'Cypress specs directory'
+  })
+  .option('args', {
+    alias: 'a',
+    type: 'string',
+    description: 'Your npm Cypress command arguments'
   }).argv;
 
 const CY_SCRIPT = argv.script;
@@ -31,6 +36,7 @@ let N_THREADS = argv.threads ? argv.threads : 2;
 const DAFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WEIGHTS_JSON = 'cypress/parallel-weights.json';
+const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : []; 
 
 const COLORS = [
   '\x1b[32m',
@@ -129,7 +135,8 @@ const start = () => {
         '--reporter',
         'cypress-parallel/json-stream.reporter.js',
         '--spec',
-        command.tests
+        command.tests,
+        ...CY_SCRIPT_ARGS
       ]);
 
       child.stdout.on('data', data => {


### PR DESCRIPTION
I added a new cli arg, to be able to add args to the script.
We used them to set the baseUrl in CI.

Honestly, I dont like to have to different args to be able to set the cmd and the cmd args.

I would be better to just have a `--cmd` arg that you can pass the entire cmd, no matter if it's npm or yarn o something else.

for example: `--cmd "yarn cy:run --config baseUrl=localhost:3000,novideo=true"`

we could have the `script` arg to be backwards compatible, and add a new arg `cmd` that would allow you to pass whatever you want to be executed. 