### PR TITLE
Add env variable to cli indicating thread number

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ npm run cy:parallel
 | --threads  | -t    | Number of threads                  | number |
 | --specsDir | -d    | Cypress specs directory.           | string |
 
+# Env variable for plugins
+A cypress plugin can read the thread number using  
+`process.env.CYPRESS_PARALLEL_THREAD`
+
 # Contributors
 Looking for contributors.
 # License

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -121,10 +121,13 @@ const start = () => {
   }));
 
   const children = [];
-  commands.forEach(command => {
+  commands.forEach((command, index) => {
     const promise = new Promise((resolve, reject) => {
       const timeMap = new Map();
       let suiteDuration = 0;
+
+      const env = Object.create(process.env);
+      env.CYPRESS_PARALLEL_THREAD = index.toString();
 
       const pckManager = isYarn
         ? 'yarn'
@@ -140,7 +143,7 @@ const start = () => {
         '--spec',
         command.tests,
         ...CY_SCRIPT_ARGS
-      ]);
+      ], {env});
 
       child.stdout.on('data', data => {
         try {


### PR DESCRIPTION
This PR adds an env variable to cypress-parallel commands

Cypress plugins code can read the thread number using process.env.CYPRESS_PARALLEL_THREAD
It's useful to seed a different DB for each thread to avoid conflicts

Fixes #13 