### PR TITLE
feature: add reporter option

### DIFF
--- a/demo-app/reporting/junit/e2e-junit-06bdf29f99ddbacffeac92a84b0e8a27.xml
+++ b/demo-app/reporting/junit/e2e-junit-06bdf29f99ddbacffeac92a84b0e8a27.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="7.438" tests="3" failures="0">
+  <testsuite name="Root Suite" timestamp="2021-03-22T23:02:36" tests="0" file="cypress/integration/1/modify-pizza.spec.js" failures="0" time="0">
+  </testsuite>
+  <testsuite name="Modify pizza" timestamp="2021-03-22T23:02:36" tests="3" failures="0" time="7.438">
+    <testcase name="Modify pizza should remove a topping" time="6.186" classname="should remove a topping">
+    </testcase>
+    <testcase name="Modify pizza should add a topping" time="0.595" classname="should add a topping">
+    </testcase>
+    <testcase name="Modify pizza can remove and add the same topping" time="0.657" classname="can remove and add the same topping">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/demo-app/reporting/junit/e2e-junit-4290066f54d534c6e1622034bdea611b.xml
+++ b/demo-app/reporting/junit/e2e-junit-4290066f54d534c6e1622034bdea611b.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="6.355" tests="3" failures="1">
+  <testsuite name="Root Suite" timestamp="2021-03-22T23:02:44" tests="0" file="cypress/integration/1/new-pizza.spec.js" failures="0" time="0">
+  </testsuite>
+  <testsuite name="Create pizza" timestamp="2021-03-22T23:02:44" tests="3" failures="1" time="6.355">
+    <testcase name="Create pizza should have the right placeholder" time="5.801" classname="should have the right placeholder">
+    </testcase>
+    <testcase name="Create pizza should show an error when pizza has no name " time="0.554" classname="should show an error when pizza has no name ">
+    </testcase>
+    <testcase name="Create pizza should create a new pizza correctly" time="0" classname="should create a new pizza correctly">
+      <failure message="expected [ Array(3) ] to deeply equal [ Array(3) ]" type="AssertionError"><![CDATA[AssertionError: expected [ Array(3) ] to deeply equal [ Array(3) ]
+    at Context.eval (http://localhost:3000/__cypress/tests?p=cypress/integration/1/new-pizza.spec.js:42:36)]]></failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/demo-app/reporting/junit/e2e-junit-5f8557e1900a8fd34d58367447da3833.xml
+++ b/demo-app/reporting/junit/e2e-junit-5f8557e1900a8fd34d58367447da3833.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="6.618" tests="3" failures="0">
+  <testsuite name="Root Suite" timestamp="2021-03-22T23:02:53" tests="0" file="cypress/integration/1/pizzas.spec.js" failures="0" time="0">
+  </testsuite>
+  <testsuite name="Pizza" timestamp="2021-03-22T23:02:53" tests="3" failures="0" time="6.618">
+    <testcase name="Pizza should navigate to products when products button is clicked" time="5.945" classname="should navigate to products when products button is clicked">
+    </testcase>
+    <testcase name="Pizza should load all pizzas" time="0.299" classname="should load all pizzas">
+    </testcase>
+    <testcase name="Pizza should open each pizza with proper ingredients" time="0.374" classname="should open each pizza with proper ingredients">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/demo-app/reporting/junit/e2e-junit-e5f7cce7e76bf1871dbc409369d54758.xml
+++ b/demo-app/reporting/junit/e2e-junit-e5f7cce7e76bf1871dbc409369d54758.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="5.953" tests="1" failures="0">
+  <testsuite name="Root Suite" timestamp="2021-03-22T23:02:29" tests="0" file="cypress/integration/1/delete-pizza.js" failures="0" time="0">
+  </testsuite>
+  <testsuite name="Delete pizza" timestamp="2021-03-22T23:02:29" tests="1" failures="0" time="5.953">
+    <testcase name="Delete pizza should delete a pizza" time="5.953" classname="should delete a pizza">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,6 +26,14 @@ const argv = yargs
     alias: 'a',
     type: 'string',
     description: 'Your npm Cypress command arguments'
+  }).option('reporter', {
+    alias: 'r',
+    type: 'string',
+    description: 'Reporter to pass to Cypress'
+  }).option('reporterOptions', { 
+    alias: 'o',
+    type: 'string',
+    description: 'Reporter options'
   }).argv;
 
 const CY_SCRIPT = argv.script;
@@ -37,7 +45,9 @@ let N_THREADS = argv.threads ? argv.threads : 2;
 const DAFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
 const WEIGHTS_JSON = 'cypress/parallel-weights.json';
-const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];
+const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : []; 
+const REPORTER = argv.reporter;
+const REPORTER_OPTIONS = argv.reporterOptions;
 
 const COLORS = [
   '\x1b[32m',
@@ -131,44 +141,61 @@ const start = () => {
         : process.platform === 'win32'
           ? 'npm.cmd'
           : 'npm';
-      const child = spawn(pckManager, [
+      
+      const childOptions = [
         'run',
         `${CY_SCRIPT}`,
         isYarn ? '' :  '--',
-        '--reporter',
-        'cypress-parallel/json-stream.reporter.js',
         '--spec',
-        command.tests,
-        ...CY_SCRIPT_ARGS
-      ]);
+        command.tests
+      ];
 
-      child.stdout.on('data', data => {
-        try {
-          const test = JSON.parse(data);
-          if (test[0] === 'pass') {
-            const testDuration = test[1].duration;
-            suiteDuration += testDuration;
-            console.log(
-              `\x1b[32m✔ \x1b[0m${test[1].title} (${testDuration}ms)`
-            );
-          }
-          if (test[0] === 'fail') {
-            console.log(`\x1b[31m✖ \x1b[0m${test[1].title} ( - ms)`);
-            console.log(`\x1b[31m${test[1].err}`);
-            console.log(`\x1b[31m${test[1].stack}`);
-          }
-          if (test[0] === 'suiteEnd' && test[1].title != null) {
-            timeMap.set(test[1].title, { ...test[1], duration: suiteDuration });
-          }
-        } catch (error) {
-          // No error logs
+      if(REPORTER){
+        childOptions.push('--reporter', REPORTER );
+      }else{
+        childOptions.push('--reporter', 'cypress-parallel/json-stream.reporter.js');
+      }
+      if(REPORTER_OPTIONS){
+        childOptions.push('--reporter-options', REPORTER_OPTIONS);
+      }
+      childOptions.push(...CY_SCRIPT_ARGS);
+
+      const child = spawn(pckManager, childOptions);
+      if(child.stdout){
+        if(REPORTER){
+          child.stdout.pipe(process.stdout);
+        }else{
+          child.stdout.on('data', data => {
+            try {
+              const test = JSON.parse(data);
+              if (test[0] === 'pass') {
+                const testDuration = test[1].duration;
+                suiteDuration += testDuration;
+                console.log(
+                  `\x1b[32m✔ \x1b[0m${test[1].title} (${testDuration}ms)`
+                );
+              }
+              if (test[0] === 'fail') {
+                console.log(`\x1b[31m✖ \x1b[0m${test[1].title} ( - ms)`);
+                console.log(`\x1b[31m${test[1].err}`);
+                console.log(`\x1b[31m${test[1].stack}`);
+              }
+              if (test[0] === 'suiteEnd' && test[1].title != null) {
+                timeMap.set(test[1].title, { ...test[1], duration: suiteDuration });
+              }
+            } catch (error) {
+              // No error logs
+            }
+          });
         }
-      });
-      child.stderr.on('data', data => {
-        // only for debug purpose
-        console.log('\x1b[31m', `${data}`);
-      });
-
+      
+      }
+      if(child.stderr){
+        child.stderr.on('data', data => {
+          // only for debug purpose
+          console.log('\x1b[31m', `${data}`);
+        });
+      }
       child.on('exit', () => {
         resolve(timeMap);
       });
@@ -178,6 +205,9 @@ const start = () => {
 
   let timeMap = new Map();
   Promise.all(children).then(resultMaps => {
+    if(REPORTER){
+      return;
+    }
     resultMaps.forEach((m, t) => {
       let totTimeThread = 0;
       for (let [name, test] of m) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -249,11 +249,16 @@ const start = () => {
       );
     });
 
+    if(totalTests - totalPasses){
+      process.stderr.write('Test failures \n');
+      process.exit(1);
+    }
     const weightsJson = JSON.stringify(specWeights);
     fs.writeFile(`${WEIGHTS_JSON}`, weightsJson, 'utf8', err => {
       if (err) throw err;
       console.log('Generated file parallel-weights.json.');
     });
+    
   });
 };
 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-parallel",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -111,14 +111,6 @@
         "readdirp": "~3.5.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "requires": {
-        "colors": "1.0.3"
-      }
-    },
     "cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -159,11 +151,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "cy:open": "cypress open",
         "cy:run": "cypress run",
         "cy:parallel": "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1",
-        "cy:parallel:spec" : "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1 -r spec",
-        "cy:parallel:junit": "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1 -r junit -o 'mochaFile=demo-app/reporting/junit/e2e-junit-[hash].xml'"
+        "cy:parallel:spec" : "node_modules/.bin/cypress-parallel -s cy:run -t 2 -d cypress/integration/1 -r spec",
+        "cy:parallel:junit": "node_modules/.bin/cypress-parallel -s cy:run -t 2 -d cypress/integration/1 -r junit -o 'mochaFile=demo-app/reporting/junit/e2e-junit-[hash].xml'"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "scripts": {
         "cy:open": "cypress open",
         "cy:run": "cypress run",
-        "cy:parallel": "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1"
+        "cy:parallel": "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1",
+        "cy:parallel:spec" : "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1 -r spec",
+        "cy:parallel:junit": "node_modules/.bin/cypress-parallel -s cy:run -t 1 -d cypress/integration/1 -r junit -o 'mochaFile=demo-app/reporting/junit/e2e-junit-[hash].xml'"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
hey @tnicola, 

Here is a quick PR that addresses adding a reporter / custom reporter to cypress-parallel. 

It seems to be working pretty good, but I'd love your feedback. 


### Changes

- added 2 new commands to the top level package.json that runs cypress-parallel with the spec reporter and the junit reporter. 
- added 2 new arguments to the cli, `-r` for the reporter, and `-o` for reporter options ( I just used what cypress used). 
- performed some null checks against `child.stdout` and `child.stderr` before adding event handler. 
- return early after all the tests have executed to skip the table generation. 
- skip adding event handler to child if a reporter is declared. I was unable to get both the junit reporter and the custom reporter working at the same time. (maybe adding a cypress-multi-reporter would get this working). 
- exit the process if passed tests != total tests. Also prevents writing the parallel-weights.json file if the tests do not pass.

