### PR TITLE
Summation problem on Pending tests

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -235,11 +235,12 @@ const start = () => {
       totalDuration += test.duration;
       totalTests += test.tests;
       totalPasses += test.passes;
-      totalPending += totalPending;
+      totalPending += test.pending;
       specWeights[name] = { time: test.duration, weight: 0 };
       table.push([name, `${formatTime(test.duration)}`, test.tests, test.passes, test.failures, test.pending]);
     }
-    table.push(["Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalTests-totalPasses, totalPending]);
+    const totalFailures = totalTests - (totalPasses + totalPending);
+    table.push(["Results", `${formatTime(totalDuration)}`, totalTests, totalPasses, totalFailures, totalPending]);
 
     console.log(table.toString());
 
@@ -249,7 +250,7 @@ const start = () => {
       );
     });
 
-    if(totalTests - totalPasses){
+    if (totalFailures > 0) {
       process.stderr.write('Test failures \n');
       process.exit(1);
     }


### PR DESCRIPTION
Hi @tnicola, I noticed the same issue that @janetlee reported and worked on a quick fix for issue #24 .

I updated the way pending tests are counted and also failed tests so the HTML table displays correct numbers. Those changes also allow to successfully generate the parallel-weights file as the number of failed tests was not properly computed.