### PR TITLE
Add .gitattributes to normalize EOL (fix #36)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
That should do the job to normalize EOL and make it work on Linux too.