### PR TITLE
Add WEIGHTS_JSON file as cli option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,6 +37,11 @@ const argv = yargs
     alias: 'o',
     type: 'string',
     description: 'Reporter options'
+  })
+  .option('weightsJson', {
+    alias: 'w',
+    type: 'string',
+    description: 'Parallel weights json file'
   }).argv;
 
 const CY_SCRIPT = argv.script;
@@ -47,7 +52,7 @@ if (!CY_SCRIPT) {
 let N_THREADS = argv.threads ? argv.threads : 2;
 const DEFAULT_WEIGHT = 1;
 const SPEC_FILES_PATH = argv.specsDir ? argv.specsDir : 'cypress/integration';
-const WEIGHTS_JSON = 'cypress/parallel-weights.json';
+const WEIGHTS_JSON = argv.weightsJson ? argv.weightsJson : 'cypress/parallel-weights.json';
 const CY_SCRIPT_ARGS = argv.args ? argv.args.split(' ') : [];
 const REPORTER = argv.reporter;
 const REPORTER_OPTIONS = argv.reporterOptions;
@@ -283,7 +288,7 @@ const start = () => {
     const weightsJson = JSON.stringify(specWeights);
     fs.writeFile(`${WEIGHTS_JSON}`, weightsJson, 'utf8', (err) => {
       if (err) throw err;
-      console.log('Generated file parallel-weights.json.');
+      console.log(`Generated file ${WEIGHTS_JSON}.`);
     });
   });
 };


### PR DESCRIPTION
This is needed if you run multiple kind of tests with cypress in order to not overwrite the weights json file. For instance if you run feature tests with cucumber preprocessor and ui tests both with cypress the parallel-weights.json file will be overwritten with the two executions and so you will never have the weights file correctly updated.