### PR TITLE
Fix: handle forward and backward slash in path for filename

### DIFF
--- a/lib/json-stream.reporter.js
+++ b/lib/json-stream.reporter.js
@@ -54,7 +54,8 @@ function calculateDuration(start, end) {
 }
 
 function writeFile(statistics) {
-  const fileName = statistics.file.replace(/\//g, '_');
+  // replace forward and backward slash with _ to generate filename
+  const fileName = statistics.file.replace(/\\|\//g, '_');
   if (!fs.existsSync(resultsPath)) {
     fs.mkdirSync(resultsPath);
   }


### PR DESCRIPTION
The filename generated for the runner-results folder was only replacing forward slash which works for Unix environment but fails on windows. PR is updating it to replace both forward or backward slash with _ so that the filename is properly generated. 

Error is thrown from line on windows
https://github.com/tnicola/cypress-parallel/blob/e43ec570525947fb18fb29f67c723903729db2ce/lib/json-stream.reporter.js#L62