### PR TITLE
Fix issue with weights file not being generated

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -23,10 +23,8 @@ function generateWeightsFile(specWeights, totalDuration, totalWeight) {
     );
   });
   const weightsJson = JSON.stringify(specWeights);
-  fs.writeFile(`${settings.weightsJSON}`, weightsJson, 'utf8', (err) => {
-    if (err) throw err;
-    console.log('Generated file parallel-weights.json.');
-  });
+  fs.writeFileSync(`${settings.weightsJSON}`, weightsJson, 'utf8');
+  console.log('Weights file generated.')
 }
 
 function collectResults(resultsPath) {

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -23,8 +23,12 @@ function generateWeightsFile(specWeights, totalDuration, totalWeight) {
     );
   });
   const weightsJson = JSON.stringify(specWeights);
-  fs.writeFileSync(`${settings.weightsJSON}`, weightsJson, 'utf8');
-  console.log('Weights file generated.')
+  try {
+    fs.writeFileSync(`${settings.weightsJSON}`, weightsJson, 'utf8');
+    console.log('Weights file generated.')
+  } catch(e) {
+    console.error(e)
+  }
 }
 
 function collectResults(resultsPath) {


### PR DESCRIPTION
Fixed an issue with the weights file not being generated after a parallel cypress run. This issue was caused by the usage of the file system method writeFile(), which is asynchronous and could not complete before the program was terminated. Instead the method writeFileSync() is used so the weights file can be properly created before the program terminates.