### PR TITLE
Added in verbose error logging

### DIFF
--- a/lib/simple-spec.reporter.js
+++ b/lib/simple-spec.reporter.js
@@ -7,7 +7,8 @@
  */
 var Base = require('mocha/lib/reporters/base');
 var constants = require('mocha/lib/runner').constants;
-var path = require('path');
+
+const { settings } = require('./settings');
 
 const {
   EVENT_TEST_PENDING,
@@ -62,7 +63,14 @@ function JSONStreamCustom(runner, options) {
 
   runner.on(EVENT_TEST_FAIL, function (test) {
     const format = color('fail', '%s');
-    consoleLog(format, getTestDescription(test));
+    if (settings.isVerbose) {
+      consoleLog(format, {
+        test: getTestDescription(test),
+        error: test.err.stack,
+      })
+    } else {
+      consoleLog(format, getTestDescription(test));
+    }
   });
 
   runner.on(EVENT_TEST_PASS, function (test) {


### PR DESCRIPTION
Added in additional error logging for failed cypress tests. This additional logging will only be shown in verbose mode.