### PR TITLE
Sort threads to run slowest group first 

### DIFF
--- a/lib/test-suites.js
+++ b/lib/test-suites.js
@@ -82,6 +82,9 @@ function distributeTestsByWeight(testSuitePaths) {
     threads[0].list.push(key);
     threads[0].weight += +value;
   }
+  
+  // Run slowest group first
+  threads.sort((a, b) => b.weight - a.weight);
 
   return threads;
 }


### PR DESCRIPTION
This small improvement has a noticeable performance gain when running a lot of heavy tests. I've done some benchmarks and the conclusion is that it's beneficial to run the "heaviest" workload-group first rather than having it run in the last thread. 