### PR TITLE
feat: add mono-repo support via reporterModulePath option

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -69,19 +69,20 @@ npx cy:parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypres
 
 ### Scripts options
 
-| Option            | Alias | Description                        | Type   |
-| ----------------- | ----- | ---------------------------------- | ------ |
-| --help            |       | Show help                          |        |
-| --version         |       | Show version number                |        |
-| --script          | -s    | Your npm Cypress command           | string |
-| --args            | -a    | Your npm Cypress command arguments | string |
-| --threads         | -t    | Number of threads                  | number |
-| --specsDir        | -d    | Cypress specs directory.           | string |
-| --reporter        | -r    | Reporter to pass to Cypress.       | string |
-| --reporterOptions | -o    | Reporter options                   | string |
-| --bail            | -b    | Exit on first failing thread       | string |
-| --verbose         | -v    | Some additional logging            | string |
-| --strictMode      | -m    | Add stricter checks after running the tests           | boolean |
+| Option               | Alias | Description                        | Type   |
+| -------------------- | ----- | ---------------------------------- | ------ |
+| --help               |       | Show help                          |        |
+| --version            |       | Show version number                |        |
+| --script             | -s    | Your npm Cypress command           | string |
+| --args               | -a    | Your npm Cypress command arguments | string |
+| --threads            | -t    | Number of threads                  | number |
+| --specsDir           | -d    | Cypress specs directory.           | string |
+| --reporter           | -r    | Reporter to pass to Cypress.       | string |
+| --reporterOptions    | -o    | Reporter options                   | string |
+| --reporterModulePath | -n    | Specify the reporter module path   | string |
+| --bail               | -b    | Exit on first failing thread       | string |
+| --verbose            | -v    | Some additional logging            | string |
+| --strictMode         | -m    | Add stricter checks after running the tests           | boolean |
 
 **NB**: If you use *cypress-cucumber-preprocesor*, please **disable** the *strictMode* to avoid possible errors:
 
@@ -89,6 +90,16 @@ npx cy:parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypres
 "scripts" :{
   ...
   "cy:parallel" : "cypress-parallel -s cy:run -t 4 -m false"
+  ...
+}
+```
+
+**NB**: If your *cypress-multi-reporters* module is not found on the same level as your Cypress suite (e.g. in a mono-repo) then you can specify the module directory for Cypress to search within.
+
+```typescript
+"scripts" :{
+  ...
+  "cy:parallel" : "cypress-parallel -s cy:run -t 4 -n .../../../node_modules/cypress-multi-reporters"
   ...
 }
 ```

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -36,6 +36,11 @@ const argv = yargs
     type: 'string',
     description: 'Reporter to pass to Cypress'
   })
+  .option('reporterModulePath', {
+    alias: 'm',
+    type: 'string',
+    description: 'Reporter module path'
+  })
   .option('reporterOptions', {
     alias: 'o',
     type: 'string',
@@ -76,6 +81,9 @@ const settings = {
   weightsJSON: 'cypress/parallel-weights.json',
   defaultWeight: 1,
   reporter: argv.reporter,
+  reporterModulePath: argv.reporterModulePath
+    ? argv.reporterModulePath
+    : 'cypress-multi-reporters',
   reporterOptions: argv.reporterOptions,
   reporterOptionsPath: argv.reporterOptionsPath,
   script: argv.script,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -37,7 +37,7 @@ const argv = yargs
     description: 'Reporter to pass to Cypress'
   })
   .option('reporterModulePath', {
-    alias: 'm',
+    alias: 'n',
     type: 'string',
     description: 'Reporter module path'
   })

--- a/lib/thread.js
+++ b/lib/thread.js
@@ -66,7 +66,7 @@ function createCommandArguments(thread) {
     createReporterConfigFile(reporterConfigPath);
   }
 
-  childOptions.push('--reporter', 'cypress-multi-reporters');
+  childOptions.push('--reporter', settings.reporterModulePath);
   childOptions.push('--reporter-options', `configFile=${reporterConfigPath}`);
   childOptions.push(...settings.scriptArguments);
 


### PR DESCRIPTION
A small, hopefully effective config option which allows the module path for cypress-multi-reporters to be overwritten . In a mono-repo it might be necessary to pass something like `../../../node_modules/cypress-multi-reporters`

Usage: add the argument `-n ${path to your modules folder}` to your CLI command or script