### PR TITLE
Add check to prevent more threads starting than there are specs found

### DIFF
--- a/lib/test-suites.js
+++ b/lib/test-suites.js
@@ -44,6 +44,12 @@ async function getTestSuitePaths() {
     console.log(JSON.stringify(fileList, null, 2));
   }
 
+  // We can't run more threads then specs
+  if (fileList.length < settings.threadCount) {
+    console.log(`Thread setting is: ${settings.threadCount}, but only: ${fileList.length} specs were found. Adjusted configuration accordingly.`)
+    settings.threadCount = fileList.length
+  }
+
   return fileList;
 }
 

--- a/lib/test-suites.js
+++ b/lib/test-suites.js
@@ -44,9 +44,9 @@ async function getTestSuitePaths() {
     console.log(JSON.stringify(fileList, null, 2));
   }
 
-  // We can't run more threads then specs
+  // We can't run more threads than suites
   if (fileList.length < settings.threadCount) {
-    console.log(`Thread setting is: ${settings.threadCount}, but only: ${fileList.length} specs were found. Adjusted configuration accordingly.`)
+    console.log(`Thread setting is ${settings.threadCount}, but only ${fileList.length} test suite(s) were found. Adjusting configuration accordingly.`)
     settings.threadCount = fileList.length
   }
 


### PR DESCRIPTION
Added a check to prevent starting more threads than there are spec files found. Possible solution for: https://github.com/tnicola/cypress-parallel/issues/129

![image](https://user-images.githubusercontent.com/39823861/191741411-d860f9a7-4a3c-41a5-90d7-ba25056377a5.png)