### PR TITLE
Fix the logic

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,9 +15,18 @@ const {
 const { executeThread } = require('./thread');
 const { resultsPath } = require('./shared-config');
 
-function cleanResultsPath() {
-  fs.remove(resultsPath);
-}
+function cleanResultsPath() { 
+  if(!fs.existsSync(resultsPath)) {
+    fs.mkdirSync(resultsPath, { recursive: true }) 
+  } else {
+    fs.readdir(resultsPath, (err, files) => {
+      if (err) console.log(err); 
+        for (const file of files) {
+          fs.unlink(path.join('path here', file), err => { if (err) console.log(err); }); 
+        } 
+      });
+    }
+  }
 
 async function start() {
   cleanResultsPath();


### PR DESCRIPTION
fix #56 

The cleanResultsPath method should have an empty folder, but the current logic was removing the directory.
The fixed logic cleans up all files in the directory but keep the directory itself.