### PR TITLE
Fix the static value

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -22,7 +22,7 @@ function cleanResultsPath() {
     fs.readdir(resultsPath, (err, files) => {
       if (err) console.log(err); 
         for (const file of files) {
-          fs.unlink(path.join('path here', file), err => { if (err) console.log(err); }); 
+          fs.unlink(path.join(resultsPath, file), err => { if (err) console.log(err); }); 
         } 
       });
     }


### PR DESCRIPTION
## Description

fix the bug from https://github.com/tnicola/cypress-parallel/pull/135

As [danyalaytekin](https://github.com/danyalaytekin) suggested [here](https://github.com/tnicola/cypress-parallel/pull/135#discussion_r1052660947), the file path should be resultPath. 
