### PR TITLE
Add thread index env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ npx cy:parallel -s cy:run -t 2 -d '<your-cypress-specs-folder>' -a '"<your-cypre
 }
 ```
 
+## Env variables
+
+### CYPRESS_THREAD
+
+You can get the current thread index by reading the `CYPRESS_THREAD` variable.
+
+```javascript
+ const threadIndex = process.env.CYPRESS_THREAD;
+ // return 1, 2, 3, 4, ...
+```
+
 # Contributors
 
 Looking for contributors.

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-parallel",
-  "version": "0.9.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-parallel",
-      "version": "0.9.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.0",

--- a/lib/thread.js
+++ b/lib/thread.js
@@ -84,7 +84,14 @@ async function executeThread(thread, index) {
   const timeMap = new Map();
 
   const promise = new Promise((resolve, reject) => {
-    const processOptions = { cwd: process.cwd(), stdio: 'inherit' };
+    const processOptions = {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        CYPRESS_THREAD: (index + 1).toString()
+      }
+    };
     const child = spawn(packageManager, commandArguments, processOptions);
 
     child.on('exit', (exitCode) => {


### PR DESCRIPTION
closes #13 

It's needed when each thread needs to target a different docker container for example

If you'd like to change the variable name, let me know 