### PR TITLE
Replace colors with @colors/colors

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const Table = require('cli-table3');
-const colors = require('colors/safe');
+const colors = require('@colors/colors/safe');
 const path = require('path');
 const fs = require('fs-extra');
 const { settings } = require('./settings');

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "cypress-parallel",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-parallel",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
+        "@colors/colors": "^1.5.0",
         "cli-table3": "^0.6.0",
-        "colors": "^1.4.0",
         "cross-spawn": "^7.0.3",
         "fs-extra": "^10.0.0",
         "glob-escape": "^0.0.2",
@@ -24,6 +24,14 @@
       },
       "peerDependencies": {
         "cypress-multi-reporters": "^1.5.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@types/color-name": {
@@ -227,6 +235,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -1185,6 +1194,11 @@
     }
   },
   "dependencies": {
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1335,7 +1349,8 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",

--- a/lib/package.json
+++ b/lib/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "cli-table3": "^0.6.0",
-    "colors": "^1.4.0",
+    "@colors/colors": "^1.5.0",
     "cross-spawn": "^7.0.3",
     "fs-extra": "^10.0.0",
     "glob-escape": "^0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,28 +17,6 @@
         "start-server-and-test": "^1.12.5"
       }
     },
-    "lib": {
-      "name": "cypress-parallel",
-      "version": "0.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "cli-table3": "^0.6.0",
-        "colors": "^1.4.0",
-        "cross-spawn": "^7.0.3",
-        "fs-extra": "^10.0.0",
-        "glob-escape": "^0.0.2",
-        "is-npm": "^5.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "mocha": "~9.2.0",
-        "yargs": "15.3.1"
-      },
-      "bin": {
-        "cypress-parallel": "cli.js"
-      },
-      "peerDependencies": {
-        "cypress-multi-reporters": "^1.5.0"
-      }
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -792,8 +770,26 @@
       }
     },
     "node_modules/cypress-parallel": {
-      "resolved": "lib",
-      "link": true
+      "version": "0.12.0",
+      "resolved": "file:lib",
+      "license": "MIT",
+      "dependencies": {
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0",
+        "cross-spawn": "^7.0.3",
+        "fs-extra": "^10.0.0",
+        "glob-escape": "^0.0.2",
+        "is-npm": "^5.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "mocha": "~9.2.0",
+        "yargs": "15.3.1"
+      },
+      "bin": {
+        "cypress-parallel": "cli.js"
+      },
+      "peerDependencies": {
+        "cypress-multi-reporters": "^1.5.0"
+      }
     },
     "node_modules/cypress/node_modules/fs-extra": {
       "version": "9.1.0",
@@ -3480,7 +3476,7 @@
       }
     },
     "cypress-parallel": {
-      "version": "file:lib",
+      "version": "0.12.0",
       "requires": {
         "cli-table3": "^0.6.0",
         "colors": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,28 @@
         "start-server-and-test": "^1.12.5"
       }
     },
+    "lib": {
+      "name": "cypress-parallel",
+      "version": "0.11.0",
+      "license": "MIT",
+      "dependencies": {
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0",
+        "cross-spawn": "^7.0.3",
+        "fs-extra": "^10.0.0",
+        "glob-escape": "^0.0.2",
+        "is-npm": "^5.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "mocha": "~9.2.0",
+        "yargs": "15.3.1"
+      },
+      "bin": {
+        "cypress-parallel": "cli.js"
+      },
+      "peerDependencies": {
+        "cypress-multi-reporters": "^1.5.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -770,26 +792,8 @@
       }
     },
     "node_modules/cypress-parallel": {
-      "version": "0.12.0",
-      "resolved": "file:lib",
-      "license": "MIT",
-      "dependencies": {
-        "cli-table3": "^0.6.0",
-        "colors": "^1.4.0",
-        "cross-spawn": "^7.0.3",
-        "fs-extra": "^10.0.0",
-        "glob-escape": "^0.0.2",
-        "is-npm": "^5.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "mocha": "~9.2.0",
-        "yargs": "15.3.1"
-      },
-      "bin": {
-        "cypress-parallel": "cli.js"
-      },
-      "peerDependencies": {
-        "cypress-multi-reporters": "^1.5.0"
-      }
+      "resolved": "lib",
+      "link": true
     },
     "node_modules/cypress/node_modules/fs-extra": {
       "version": "9.1.0",
@@ -3476,7 +3480,7 @@
       }
     },
     "cypress-parallel": {
-      "version": "0.12.0",
+      "version": "file:lib",
       "requires": {
         "cli-table3": "^0.6.0",
         "colors": "^1.4.0",


### PR DESCRIPTION
I was running into this documented issue with colors when trying to run this tool: https://github.com/tnicola/cypress-parallel/issues/165.

This migrates the repo away from colors (which has some documented issues) and onto a potentially more stable alternative.