### PR TITLE
Fix: Update staggered start delay thread.js

### DIFF
--- a/lib/thread.js
+++ b/lib/thread.js
@@ -79,7 +79,7 @@ async function executeThread(thread, index) {
   const commandArguments = createCommandArguments(thread);
 
   // staggered start (when executed in container with xvfb ends up having a race condition causing intermittent failures)
-  await sleep(index * 2000);
+  await sleep((index +1) * 2000);
 
   const timeMap = new Map();
 


### PR DESCRIPTION
We are using Cypress-parallel to run our tests in 6 parallel threads inside a docker image cypress/included 12.14.

But we are facing a random issues (roughly 2/10 runs) where the second thread's command is triggered but doesn't execute any tests, meaning cypress is not even opened. 

This seems to be similar to issue #122, but the difference is that the run is not even started. 
Delaying the staggered threads a bit more seems to solve the issue. 