### PR TITLE
Fix typo in README.md in npx command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ or
 Run with npx (no package installation needed)
 
 ```
-npx cy:parallel -s cy:run -t 2 -d '<your-cypress-specs-folder>' -a '"<your-cypress-cmd-args>"'
+npx cypress-parallel -s cy:run -t 2 -d '<your-cypress-specs-folder>' -a '"<your-cypress-cmd-args>"'
 ```
 
 ## Passing Specs


### PR DESCRIPTION
Pretty sure this is a typo, and `npx cypress-parallel` was what was intended here.