### PR TITLE
fix: support reportDir mocha reporter option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -103,9 +103,15 @@ async function start() {
     console.error(
       'Some test suites likely terminated without passing on results, exit with error'
     );
-    const missingTestResults = testSuitePaths.filter(
-      (path) => !timeMap.get(path)
-    );
+    const missingTestResults = [].concat(testSuitePaths);
+    timeMap.forEach((_, pathEnd) => {
+      const index = missingTestResults.findIndex((p) =>
+        path.resolve(p).endsWith(pathEnd)
+      );
+      if (index > -1) {
+        missingTestResults.splice(index, 1);
+      }
+    });
     console.log(
       `The following test suites are missing results: ${missingTestResults}`
     );

--- a/lib/json-stream.reporter.js
+++ b/lib/json-stream.reporter.js
@@ -10,7 +10,7 @@ var constants = require('mocha/lib/runner').constants;
 var path = require('path');
 var fs = require('fs');
 
-const { resultsPath } = require('./shared-config');
+const { resultsPath: defaultResultsPath } = require('./shared-config');
 
 const { EVENT_SUITE_END } = constants;
 
@@ -43,7 +43,7 @@ function JSONStreamCustom(runner, options) {
   }
 
   runner.on(EVENT_SUITE_END, function () {
-    writeFile(cleanStatistics());
+    writeFile.apply(self, [cleanStatistics()]);
   });
 }
 
@@ -54,10 +54,13 @@ function calculateDuration(start, end) {
 }
 
 function writeFile(statistics) {
+  const resultsPath = this.options.reporterOptions.reportDir
+    ? path.join(process.cwd(), this.options.reporterOptions.reportDir)
+    : defaultResultsPath;
   // replace forward and backward slash with _ to generate filename
   const fileName = statistics.file.replace(/\\|\//g, '_');
   if (!fs.existsSync(resultsPath)) {
-    fs.mkdirSync(resultsPath);
+    fs.mkdirSync(resultsPath, { recursive: true });
   }
   const specResultPath = path.join(resultsPath, `${fileName}.json`);
   fs.writeFileSync(specResultPath, JSON.stringify(statistics, null, 2));

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -24,10 +24,15 @@ function generateWeightsFile(specWeights, totalDuration, totalWeight) {
   });
   const weightsJson = JSON.stringify(specWeights);
   try {
-    fs.writeFileSync(`${settings.weightsJSON}`, weightsJson, 'utf8');
-    console.log('Weights file generated.')
-  } catch(e) {
-    console.error(e)
+    const filepath = path.join(process.cwd(), `${settings.weightsJSON}`);
+    const directory = path.dirname(filepath);
+    if (!fs.existsSync(directory)) {
+      fs.mkdirSync(directory, { recursive: true });
+    }
+    fs.writeFileSync(filepath, weightsJson, 'utf8');
+    console.log('Weights file generated.');
+  } catch (e) {
+    console.error(e);
   }
 }
 


### PR DESCRIPTION
Adding other fixes to make file paths less “hardcoded”

Maybe this fixes #90 