### PR TITLE
ci: ensure README files match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         node-version: '22.14.0'
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Ensure README files match
+    - run: |
+        diff ./README.md ./lib/README.md
     - name: Prepare demo-app
       run: |
         cd pizza-demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Ensure README files match
-    - run: |
+      run: |
         diff ./README.md ./lib/README.md
     - name: Prepare demo-app
       run: |

--- a/lib/README.md
+++ b/lib/README.md
@@ -23,13 +23,13 @@ Reduce up to 40% your Cypress suite execution time parallelizing the test run on
 ## Install
 
 ```
-npm i cypress-parallel
+npm i cypress-parallel -D
 ```
 
 or
 
 ```
-yarn add cypress-parallel
+yarn add cypress-parallel -D
 ```
 
 ## Add a new script
@@ -40,7 +40,7 @@ In your `package.json` add a new script:
 "scripts" :{
   ...
   "cy:run": "cypress run", // It can be any cypress command with any argument
-  "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypress-cmd-args>\"'"
+  "cy:parallel" : "cypress-parallel -s cy:run -t 2 -d '<your-cypress-specs-folder>' -a '\"<your-cypress-cmd-args>\"'"
   ...
 }
 ```
@@ -64,26 +64,33 @@ or
 Run with npx (no package installation needed)
 
 ```
-npx cy:parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypress-cmd-args>\"'
+npx cy:parallel -s cy:run -t 2 -d '<your-cypress-specs-folder>' -a '"<your-cypress-cmd-args>"'
+```
+
+## Passing Specs
+
+```
+cypress-parallel -s cy:run -t 2 -a '\"<your-cypress-cmd-args>\"' --spec path/to/spec1.spec.js path/to/spec2.spec.js
 ```
 
 ### Scripts options
 
-| Option            | Alias | Description                        | Type   |
-| ----------------- | ----- | ---------------------------------- | ------ |
-| --help            |       | Show help                          |        |
-| --version         |       | Show version number                |        |
-| --script          | -s    | Your npm Cypress command           | string |
-| --args            | -a    | Your npm Cypress command arguments | string |
-| --threads         | -t    | Number of threads                  | number |
-| --specsDir        | -d    | Cypress specs directory            | string |
-| --weightsJson     | -w    | Parallel weights json file         | string |
-| --reporter        | -r    | Reporter to pass to Cypress.       | string |
-| --reporterOptions | -o    | Reporter options                   | string |
-| --reporterModulePath | -n    | Specify the reporter module path   | string |
-| --bail            | -b    | Exit on first failing thread       | string |
-| --verbose         | -v    | Some additional logging            | string |
-| --strictMode      | -m    | Add stricter checks after running the tests           | boolean |
+| Option               | Alias | Description                                 | Type    |
+| -------------------- | ----- | ------------------------------------------- | ------- |
+| --help               |       | Show help                                   |         |
+| --version            |       | Show version number                         |         |
+| --script             | -s    | Your npm Cypress command                    | string  |
+| --args               | -a    | Your npm Cypress command arguments          | string  |
+| --threads            | -t    | Number of threads                           | number  |
+| --specsDir           | -d    | Cypress specs directory                     | string  |
+| --spec               |       | Cypress spec file paths                     | string  |
+| --weightsJson        | -w    | Parallel weights json file                  | string  |
+| --reporter           | -r    | Reporter to pass to Cypress.                | string  |
+| --reporterOptions    | -o    | Reporter options                            | string  |
+| --reporterModulePath | -n    | Specify the reporter module path            | string  |
+| --bail               | -b    | Exit on first failing thread                | string  |
+| --verbose            | -v    | Some additional logging                     | string  |
+| --strictMode         | -m    | Add stricter checks after running the tests | boolean |
 
 **NB**: If you use *cypress-cucumber-preprocesor*, please **disable** the *strictMode* to avoid possible errors:
 
@@ -105,10 +112,21 @@ npx cy:parallel -s cy:run -t 2 -d <your-cypress-specs-folder> -a '\"<your-cypres
 }
 ```
 
+## Env variables
+
+### CYPRESS_THREAD
+
+You can get the current thread index by reading the `CYPRESS_THREAD` variable.
+
+```javascript
+ const threadIndex = process.env.CYPRESS_THREAD;
+ // return 1, 2, 3, 4, ...
+```
+
 # Contributors
 
 Looking for contributors.
 
 # License
 
-MIT
+This project is licensed under the MIT license. See [LICENSE](LICENSE).


### PR DESCRIPTION
From what I understand, 1 README is for GitHub, 1 is for NPM. They should match for sure (currently, 1 is outdated and missing a CLI arg). This CI step checks that they match (fails if doesn't)